### PR TITLE
Fix loading inline config from NLog.config

### DIFF
--- a/src/NLog.RollbarSharp.csproj
+++ b/src/NLog.RollbarSharp.csproj
@@ -30,8 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>packages\Newtonsoft.Json.5.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=2.0.1.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -48,6 +49,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/RollbarTarget.cs
+++ b/src/RollbarTarget.cs
@@ -19,14 +19,14 @@ namespace NLog.RollbarSharp
         public Layout Language { get; set; }
 
         public Layout Framework { get; set; }
-        
+
         public Layout Title { get; set; }
 
         public RollbarTarget()
         {
             Title = "${message}";
         }
-        
+
         protected override void Write(LogEventInfo logEvent)
         {
             var client = CreateClient(logEvent);
@@ -51,27 +51,26 @@ namespace NLog.RollbarSharp
         /// <returns></returns>
         private RollbarClient CreateClient(LogEventInfo logEvent)
         {
-            var client = new RollbarClient();
-            client.RequestStarting += RollbarClientRequestStarting;
-            client.RequestCompleted += RollbarClientRequestCompleted;
-
-            if (!string.IsNullOrEmpty(AccessToken))
-                client.Configuration.AccessToken = AccessToken;
+            var configuration = new Configuration(AccessToken);
 
             if (!string.IsNullOrEmpty(Endpoint))
-                client.Configuration.Endpoint = Endpoint;
+                configuration.Endpoint = Endpoint;
 
             if (Environment != null)
-                client.Configuration.Environment = Environment.Render(logEvent);
+                configuration.Environment = Environment.Render(logEvent);
 
             if (Platform != null)
-                client.Configuration.Platform = Platform.Render(logEvent);
+                configuration.Platform = Platform.Render(logEvent);
 
             if (Language != null)
-                client.Configuration.Language = Language.Render(logEvent);
+                configuration.Language = Language.Render(logEvent);
 
             if (Framework != null)
-                client.Configuration.Framework = Framework.Render(logEvent);
+                configuration.Framework = Framework.Render(logEvent);
+
+            var client = new RollbarClient(configuration);
+            client.RequestStarting += RollbarClientRequestStarting;
+            client.RequestCompleted += RollbarClientRequestCompleted;
 
             return client;
         }
@@ -83,7 +82,7 @@ namespace NLog.RollbarSharp
         /// <param name="args"></param>
         private static void RollbarClientRequestStarting(object source, RequestStartingEventArgs args)
         {
-            var client = (RollbarClient) source;
+            var client = (RollbarClient)source;
             InternalLogger.Debug("Sending request to {0}: {1}", client.Configuration.Endpoint, args.Payload);
         }
 

--- a/src/RollbarTarget.cs
+++ b/src/RollbarTarget.cs
@@ -1,4 +1,5 @@
-﻿using NLog.Common;
+﻿using System;
+using NLog.Common;
 using NLog.Layouts;
 using NLog.Targets;
 using RollbarSharp;
@@ -29,18 +30,25 @@ namespace NLog.RollbarSharp
 
         protected override void Write(LogEventInfo logEvent)
         {
-            var client = CreateClient(logEvent);
-            var level = ConvertLogLevel(logEvent.Level);
-            var title = Title.Render(logEvent);
+            try
+            {
+                var client = CreateClient(logEvent);
+                var level = ConvertLogLevel(logEvent.Level);
+                var title = Title.Render(logEvent);
 
-            var notice = logEvent.Exception != null
-                             ? client.NoticeBuilder.CreateExceptionNotice(logEvent.Exception)
-                             : client.NoticeBuilder.CreateMessageNotice(logEvent.FormattedMessage);
+                var notice = logEvent.Exception != null
+                                 ? client.NoticeBuilder.CreateExceptionNotice(logEvent.Exception)
+                                 : client.NoticeBuilder.CreateMessageNotice(logEvent.FormattedMessage);
 
-            notice.Level = level;
-            notice.Title = title;
+                notice.Level = level;
+                notice.Title = title;
 
-            client.Send(notice);
+                client.Send(notice);
+            }
+            catch (Exception exception)
+            {
+                InternalLogger.Error(exception.ToString());
+            }
         }
 
         /// <summary>

--- a/src/app.config
+++ b/src/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
   <package id="NLog" version="2.0.0.2000" targetFramework="net40" />
   <package id="RollbarSharp" version="0.2.0.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Before the change NLog.RollbarSharp required to have an access token in app/web.config file despite that it was inlined in NLog.config
