### PR TITLE
Update dependencies

### DIFF
--- a/src/NLog.RollbarSharp.csproj
+++ b/src/NLog.RollbarSharp.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NLog.RollbarSharp</RootNamespace>
     <AssemblyName>NLog.RollbarSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -20,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,17 +30,18 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
       <HintPath>packages\Newtonsoft.Json.5.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=2.0.1.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.4.3.4\lib\net45\NLog.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\NLog.2.0.0.2000\lib\net40\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="RollbarSharp">
-      <HintPath>packages\RollbarSharp.0.2.0.0\lib\net40\RollbarSharp.dll</HintPath>
+    <Reference Include="RollbarSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\RollbarSharp.1.0.0.0\lib\net45\RollbarSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/RollbarTarget.cs
+++ b/src/RollbarTarget.cs
@@ -40,7 +40,7 @@ namespace NLog.RollbarSharp
             notice.Level = level;
             notice.Title = title;
 
-            client.Send(notice);
+            client.Send(notice,null);
         }
 
         /// <summary>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net40" />
-  <package id="NLog" version="2.0.0.2000" targetFramework="net40" />
-  <package id="RollbarSharp" version="0.2.0.0" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="NLog" version="4.3.4" targetFramework="net45" />
+  <package id="RollbarSharp" version="1.0.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I had to make a few changes to get NLog.RollbarSharp working in my project. They are:
- Change target framework to .NET 4.5
- Build against newer versions of NLog and RollbarSharp
- Add second parameter to the call to RollbarClient.Send in RollbarTarget

Thanks,
Jim.
